### PR TITLE
ct: fix setting cgroup parameters when a new container is started

### DIFF
--- a/src/cgroups.c
+++ b/src/cgroups.c
@@ -251,7 +251,7 @@ int cgroups_create(struct container *ct)
 	}
 
 	list_for_each_entry(cfg, &ct->cg_configs, l) {
-		ret = local_config_controller(&ct->h, cfg->ctype, cfg->param, cfg->value);
+		ret = config_controller(ct, cfg->ctype, cfg->param, cfg->value);
 		if (ret)
 			return -LCTERR_CGCONFIG;
 	}


### PR DESCRIPTION
Added changes to cgroups_create() function to call config_controller() instead
of local_config_controller() function which postpones the cgroup configuration
if the container is not running. This change ensures that cgroup limits will be
set correctly for the process which spawns/enters in the container.

Signed-off-by: monali monali.porob@huawei.com
Signed-off-by: Andrey Vagin avagin@openvz.org
