### PR TITLE
Use linux/sched.h instead of sched.h

### DIFF
--- a/src/include/ct.h
+++ b/src/include/ct.h
@@ -3,7 +3,8 @@
 
 #include <stdbool.h>
 #include <stdarg.h>
-#include <sched.h>
+
+#include <linux/sched.h>
 
 #include "uapi/libct.h"
 


### PR DESCRIPTION
sched.h requires __USE_GNU usage for CLONE_* constants