### PR TITLE
Remove -Wa,--noexectack from CFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -26,7 +26,7 @@ obj-$(CONFIG_SELINUX)	+= lsm/selinux.o
 obj-y			+= lsm/nop.o
 obj-y			+= systemd.o
 
-cflags-y		+= -fPIC -Wa,--noexecstack -fno-stack-protector
+cflags-y		+= -fPIC -fno-stack-protector
 cflags-so		+= -rdynamic
 
 .SECONDARY:


### PR DESCRIPTION
Arguments looks unnecessary and clang produces warnings
"error: argument unused during compilation: '-Wa,--noexecstack'".